### PR TITLE
String escaping nitpick

### DIFF
--- a/mapreduce.go
+++ b/mapreduce.go
@@ -22,7 +22,7 @@ func (mr *MapReduce) Add(bucket string, key string) {
 }
 
 func (mr *MapReduce) LinkBucket(name string, keep bool) {
-	link := "{\"link\":{\"bucket\":\"" + name + "\", \"tag\":\"_\",\"keep\":"
+	link := `{"link":{"bucket":"` + name + `", "tag":"_","keep":`
 	if keep {
 		link = link + "true}}"
 	} else {
@@ -32,13 +32,13 @@ func (mr *MapReduce) LinkBucket(name string, keep bool) {
 }
 
 func (mr *MapReduce) Map(fun string, keep bool) {
-	m := "{\"map\":{\"language\":\"javascript\",\"keep\":"
+	m := `{"map":{"language":"javascript","keep":`
 	if keep {
 		m = m + "true,"
 	} else {
 		m = m + "false,"
 	}
-	m = m + "\"source\":\"" + fun + "\"}}"
+	m = m + `"source":"` + fun + `"}}`
 	mr.phases = append(mr.phases, m)
 }
 
@@ -64,7 +64,7 @@ func (mr *MapReduce) Query() (query []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	q := "{\"inputs\":" + string(inputs) + ", \"query\":["
+	q := `{"inputs":` + string(inputs) + `, "query":[`
 	for i, s := range mr.phases {
 		if i > 0 {
 			q = q + ","

--- a/model.go
+++ b/model.go
@@ -209,7 +209,7 @@ func (c *Client) SaveAs(newKey string, dest interface{}) (err error) {
 		return errors.New("Destination struct is not instantiated using riak.New or riak.Load")
 	}
 	// Start with the _type
-	data := []byte("{\"_type\":")
+	data := []byte(`{"_type":`)
 	js, _ := json.Marshal(dt.Name())
 	data = append(data, js...)
 	// Now add the other fields, as long as they're "simple" fields

--- a/riak_test.go
+++ b/riak_test.go
@@ -365,22 +365,22 @@ func TestRunMapReduce(t *testing.T) {
 	obj1 := bucket.New("mrobj1")
 	assert.T(t, obj1 != nil)
 	obj1.ContentType = "application/json"
-	obj1.Data = []byte("{\"k\":\"v\"}")
+	obj1.Data = []byte(`{"k":"v"}`)
 	err := obj1.Store()
 	assert.T(t, err == nil)
 	// Create object 2
 	obj2 := bucket.New("mrobj2")
 	assert.T(t, obj2 != nil)
 	obj2.ContentType = "application/json"
-	obj2.Data = []byte("{\"k\":\"v2\"}")
+	obj2.Data = []byte(`{"k":"v2"}`)
 	err = obj2.Store()
 	assert.T(t, err == nil)
 	// Link them
 	obj1.LinkTo(obj2, "test")
 	obj1.Store()
 
-	//q := "{\"inputs\":[[\"client_test.go\",\"mrobj1\"]],\"query\":[{\"map\":{\"language\":\"javascript\",\"keep\":true,\"source\":\"function(v) { return [JSON.parse(v.values[0].data)]; }\"}}]}"
-	q := "{\"inputs\":[[\"client_test.go\",\"mrobj1\"]],\"query\":[{\"map\":{\"language\":\"javascript\",\"keep\":true,\"source\":\"function(v) { return [v]; }\"}}]}"
+	//q := `{"inputs":[["client_test.go","mrobj1"]],"query":[{"map":{"language":"javascript","keep":true,"source":"function(v) { return [JSON.parse(v.values[0].data)]; }"}}]}`
+	q := `{"inputs":[["client_test.go","mrobj1"]],"query":[{"map":{"language":"javascript","keep":true,"source":"function(v) { return [v]; }"}}]}`
 
 	mr, err := client.RunMapReduce(q)
 	assert.T(t, err == nil)
@@ -485,14 +485,14 @@ func TestRunConnectionPool(t *testing.T) {
 	obj1 := bucket.New("mrobj1")
 	assert.T(t, obj1 != nil)
 	obj1.ContentType = "application/json"
-	obj1.Data = []byte("{\"k\":\"v\"}")
+	obj1.Data = []byte(`{"k":"v"}`)
 	err := obj1.Store()
 	assert.T(t, err == nil)
 	// Create object 2
 	obj2 := bucket.New("mrobj2")
 	assert.T(t, obj2 != nil)
 	obj2.ContentType = "application/json"
-	obj2.Data = []byte("{\"k\":\"v2\"}")
+	obj2.Data = []byte(`{"k":"v2"}`)
 	err = obj2.Store()
 	assert.T(t, err == nil)
 	// Link them
@@ -502,7 +502,7 @@ func TestRunConnectionPool(t *testing.T) {
 	receiver := make(chan int)
 	// MR job with (very dirty) sleep of 2 seconds, send "1" to the channel afterwards
 	go func() {
-		q := "{\"inputs\":[[\"client_test.go\",\"mrobj1\"]],\"query\":[{\"map\":{\"language\":\"javascript\",\"keep\":true,\"source\":\"function(v) { var start = new Date().getTime(); while (new Date().getTime() < start + 2000); return [v]; }\"}}]}"
+		q := `{"inputs":[["client_test.go","mrobj1"]],"query":[{"map":{"language":"javascript","keep":true,"source":"function(v) { var start = new Date().getTime(); while (new Date().getTime() < start + 2000); return [v]; }"}}]}`
 		mr, err := client.RunMapReduce(q)
 		assert.T(t, err == nil)
 		assert.T(t, len(mr) == 1)


### PR DESCRIPTION
I'm reading through the code and using backticks instead of escaping all the quotes is a lot more readable IMHO.  This is obviously a nitpick and does not change how the code runs so feel free to do what you wish with it.
