### PR TITLE
Use a seperate new structure for retreiving siblings.

### DIFF
--- a/model.go
+++ b/model.go
@@ -235,17 +235,18 @@ func (m *Model) GetSiblings(dest interface{}) (err error) {
 	}
 	count = 0
 	// Double check the parent and get the Value and Type
-	dv, dt, _, _, err := check_dest(m.parent)
+	_, dt, _, _, err := check_dest(m.parent)
 	if err != nil {
 		return err
 	}
 	// Walk over the slice and map the data for each sibling
 	for _, sibling := range m.robject.Siblings {
 		if len(sibling.Data) != 0 {
-			// Map the data onto the parent struct
-			err = client.mapData(dv, dt, sibling.Data, sibling.Links, m.parent)
-			// Copy the parent struct to the slice element
-			v.Index(count).Set(reflect.ValueOf(m.parent).Elem())
+			// Map the data onto a temporary struct
+			tmp := reflect.New(dt)
+			err = client.mapData(tmp.Elem(), dt, sibling.Data, sibling.Links, tmp.Interface())
+			// Copy the temporary struct to the slice element
+			v.Index(count).Set(tmp.Elem())
 			count += 1
 		}
 	}


### PR DESCRIPTION
When the model structure contains a slice of some elements,
re-using the same structure for the json decoding cause the same
backing array to be used for each decode.  Thus the decoding
will overwrite the data in previous siblings.  Instead, make a
new structure for each sibling to get the decode process to
allocate a new array.  Also, add a unit test to verify the fix.

Note, byte slices do not appear to exhibit this problem.  Slices
of byte slices do for the first slice.
