### PR TITLE
When fetching an RObject with an explicit client, don't use defaultClient.

### DIFF
--- a/riak_test.go
+++ b/riak_test.go
@@ -106,6 +106,14 @@ func TestGetAndDeleteObject(t *testing.T) {
 	obj, err := bucket.Get("abc", R1, PR1)
 	assert.T(t, err == nil)
 	assert.T(t, obj != nil)
+
+	// Also test the GetFrom function works the same here too.  Kill the defaultClient to trigger any
+	// bugs related to using it.
+	defaultClient.Close()
+	defaultClient = nil
+	obj, err = client.GetFrom("client_test.go", "abc", R1, PR1)
+	assert.T(t, err == nil)
+	assert.T(t, obj != nil)
 	/*
 		t.Logf("obj key  : %s\n", obj.Key)
 		t.Logf("vclock   : %s\n", obj.Vclock)

--- a/robject.go
+++ b/robject.go
@@ -257,7 +257,7 @@ func (b *Bucket) Get(key string, options ...map[string]uint32) (obj *RObject, er
 // Get directly from a bucket, without creating a bucket first
 func (c *Client) GetFrom(bucketname string, key string, options ...map[string]uint32) (obj *RObject, err error) {
 	var bucket *Bucket
-	bucket, err = defaultClient.Bucket(bucketname)
+	bucket, err = c.Bucket(bucketname)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
When fetching an RObject using an explicit client, the implementation would
use defaultClient to fetch the bucket.  Since defaultClient is uninitialized,
this of course panics later on a nil pointer.  Thus switch to using the client
as passed.  Also add to a test to ensure it won't reappear.
