### PR TITLE
Return tombstones (Vclock) so a K/V can be rewritten directly after a de...

### DIFF
--- a/riak_test.go
+++ b/riak_test.go
@@ -128,6 +128,10 @@ func TestGetAndDeleteObject(t *testing.T) {
 	*/
 	err = bucket.Delete("abc", R1, PR1, W1, DW1, PW1)
 	assert.T(t, err == nil)
+	// Immediately get the same object again, should have a valid Vclock (tombstone)
+	obj, err = bucket.Get("abc")
+	assert.T(t, len(obj.Vclock) > 0)
+	assert.T(t, err == NotFound)
 }
 
 func TestObjectsWithSiblings(t *testing.T) {


### PR DESCRIPTION
Recently an item came up on the mailing list with the subject: "Quickly deleting + recreating item in Riak deletes new item"

Turns out this or something very much related was discussed earlier:
http://lists.basho.com/pipermail/riak-users_lists.basho.com/2011-June/004601.html

As suggested by Andrew Thompson here:
http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-July/012520.html

this pull request sets 'deletedvclock' and returns the Vclock for tombstones / items that were deleted very recently.
