### PR TITLE
FIX - Removed links were not saved correctly

### DIFF
--- a/model.go
+++ b/model.go
@@ -427,6 +427,8 @@ func (c *Client) SaveAs(newKey string, dest Resolver) (err error) {
 	if err != nil {
 		return err
 	}
+	// Clear the old links
+	model.robject.Links = []Link{}
 	// Now add the Links
 	for i := 0; i < dt.NumField(); i++ {
 		ft := dt.Field(i)

--- a/model_test.go
+++ b/model_test.go
@@ -180,6 +180,15 @@ func TestModelWithManyLinks(t *testing.T) {
 	t.Logf("TestingModelWithManyLinks - removing a link %v", err)
 	assert.T(t, err == nil)
 	assert.T(t, doc2.Friends.Len() == 1)
+	err = doc2.Save()
+	assert.T(t, err == nil)
+	// Test that f2 was removed
+	var doc3 FriendLinks
+	err = client.Load("testmodel.go", "TestMany", &doc3)
+	assert.T(t, err == nil)
+	assert.T(t, len(doc3.Friends) == 1)
+	assert.T(t, doc3.Friends.Len() == 1)
+	assert.T(t, doc3.Friends[0].link.Key == "f1") // Check if the correct link is remaining
 }
 
 /*


### PR DESCRIPTION
Links were removed from the model, but not in the underlying robject.Links. Obviously the test didn't catch this, the new test does.
