### PR TITLE
Load a counter without necessarily reading it.

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -165,6 +165,16 @@ func (b *Bucket) GetCounter(key string, options ...map[string]uint32) (c *Counte
 	return
 }
 
+func (b *Bucket) GetCounterWithoutLoad(key string, options ...map[string]uint32) (c *Counter, err error) {
+	c = &Counter{
+		Bucket:  b,
+		Key:     key,
+		Options: options,
+	}
+
+	return
+}
+
 // Get counter directly from a bucket, without creating a bucket first
 func (c *Client) GetCounterFrom(bucketname string, key string, options ...map[string]uint32) (counter *Counter, err error) {
 	var bucket *Bucket

--- a/counter_test.go
+++ b/counter_test.go
@@ -87,4 +87,24 @@ func TestCounter(t *testing.T) {
 	assert.T(t, err == nil)
 	err = c1.Reload()
 	assert.T(t, c1.Value == 5)
+
+	// Increment a counter without a read
+	// First get the base (so we actually want to read in this case)... This is purely for testing purposes
+	c4, err := bucket.GetCounter("counter_3")
+	assert.T(t, err == nil)
+	base = c4.Value
+	// Grab the counter again, but this time don't load the value
+	c5, err := bucket.GetCounterWithoutLoad("counter_3")
+	assert.T(t, err == nil)
+
+	// Increment another counter
+	err = c5.Increment(3)
+	assert.T(t, err == nil)
+	err = c5.Increment(5)
+	assert.T(t, err == nil)
+
+	// Actually load the counter at this point
+	err = c5.Reload()
+	assert.T(t, err == nil)
+	assert.T(t, c5.Value == (base+8))
 }


### PR DESCRIPTION
In the case of counters, it's useful to not always have to read in a value prior to writing.  This can reduce volume on clusters & improve throughput.  I've verified that this is not strictly required as per the responses on the riak mailing list.

I'm not married to structuring the code this way, but I didn't want to start doing any refactoring without prior approval.  I figured I'd point out the change and rejigger it however you'd prefer.
