### PR TITLE
Bugfix - first write to rfile with less than one chunk_size bytes

### DIFF
--- a/rfile.go
+++ b/rfile.go
@@ -176,7 +176,7 @@ func (r *RFile) Write(p []byte) (n int, err error) {
 		wpos += towrite
 		// Update the size if necessary
 		if r.pos > r.size {
-			if (r.pos / r.chunk_size) > (r.size / r.chunk_size) {
+			if ((r.pos / r.chunk_size) > (r.size / r.chunk_size)) || r.root.Meta["chunk_count"] == "0" {
 				// Update the root KV
 				r.root.Meta["chunk_count"] = strconv.Itoa(r.pos/r.chunk_size + 1)
 				err = r.root.Store()

--- a/rfile_test.go
+++ b/rfile_test.go
@@ -15,6 +15,8 @@ func TestRFile(t *testing.T) {
 	b, err := f.Write([]byte{'1', '2', '3', '4', '5', '6', '7', '8'})
 	assert.T(t, err == nil)
 	assert.T(t, b == 8)
+	// Check the root was updated
+	assert.T(t, f.root.Meta["chunk_count"] == "1")
 	// Add a full chunk
 	extra := make([]byte, 1024)
 	b, err = f.Write(extra)


### PR DESCRIPTION
For an empty RFile, the first write with less than one chunk_size bytes did not update the the the chunk_count in the root node
