### PR TITLE
Added Bucket Search Index Property

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -13,6 +13,7 @@ type Bucket struct {
 	allowMult     bool
 	lastWriteWins bool
 	search        bool
+	searchIndex   string
 	datatype      string
 	consistent    bool
 }
@@ -113,9 +114,17 @@ func (b *Bucket) Search() bool {
 	return b.search
 }
 
+// Return the search index property of a bucket
+func (b *Bucket) SearchIndex() string {
+	return b.searchIndex
+}
+
 // Set the search property of a bucket
 func (b *Bucket) SetSearch(search bool) (err error) {
 	props := &pb.RpbBucketProps{NVal: &b.nval, AllowMult: &b.allowMult, LastWriteWins: &b.lastWriteWins, Search: &search}
+	if i := b.searchIndex; i != "" {
+		props.SearchIndex = []byte(i)
+	}
 	req := &pb.RpbSetBucketReq{Bucket: []byte(b.name), Type: []byte(b.bucket_type), Props: props}
 	err, conn := b.client.request(req, rpbSetBucketReq)
 	if err != nil {
@@ -129,9 +138,31 @@ func (b *Bucket) SetSearch(search bool) (err error) {
 	return nil
 }
 
+// Set the search property of a bucket
+func (b *Bucket) SetSearchIndex(index string) (err error) {
+	props := &pb.RpbBucketProps{NVal: &b.nval, AllowMult: &b.allowMult, LastWriteWins: &b.lastWriteWins, Search: &b.search}
+	if i := index; i != "" {
+		props.SearchIndex = []byte(index)
+	}
+	req := &pb.RpbSetBucketReq{Bucket: []byte(b.name), Type: []byte(b.bucket_type), Props: props}
+	err, conn := b.client.request(req, rpbSetBucketReq)
+	if err != nil {
+		return err
+	}
+	err = b.client.response(conn, req)
+	if err != nil {
+		return err
+	}
+	b.searchIndex = index
+	return nil
+}
+
 // Set the nval property of a bucket
 func (b *Bucket) SetNVal(nval uint32) (err error) {
 	props := &pb.RpbBucketProps{NVal: &nval, AllowMult: &b.allowMult, LastWriteWins: &b.lastWriteWins, Search: &b.search}
+	if i := b.searchIndex; i != "" {
+		props.SearchIndex = []byte(i)
+	}
 	req := &pb.RpbSetBucketReq{Bucket: []byte(b.name), Type: []byte(b.bucket_type), Props: props}
 	err, conn := b.client.request(req, rpbSetBucketReq)
 	if err != nil {
@@ -148,6 +179,9 @@ func (b *Bucket) SetNVal(nval uint32) (err error) {
 // Set the allowMult property of a bucket
 func (b *Bucket) SetAllowMult(allowMult bool) (err error) {
 	props := &pb.RpbBucketProps{NVal: &b.nval, AllowMult: &allowMult, LastWriteWins: &b.lastWriteWins, Search: &b.search}
+	if i := b.searchIndex; i != "" {
+		props.SearchIndex = []byte(i)
+	}
 	req := &pb.RpbSetBucketReq{Bucket: []byte(b.name), Type: []byte(b.bucket_type), Props: props}
 	err, conn := b.client.request(req, rpbSetBucketReq)
 	if err != nil {
@@ -164,6 +198,9 @@ func (b *Bucket) SetAllowMult(allowMult bool) (err error) {
 // Set the lastWriteWins property of a bucket
 func (b *Bucket) SetLastWriteWins(lastWriteWins bool) (err error) {
 	props := &pb.RpbBucketProps{NVal: &b.nval, AllowMult: &b.allowMult, LastWriteWins: &lastWriteWins, Search: &b.search}
+	if i := b.searchIndex; i != "" {
+		props.SearchIndex = []byte(i)
+	}
 	req := &pb.RpbSetBucketReq{Bucket: []byte(b.name), Type: []byte(b.bucket_type), Props: props}
 	err, conn := b.client.request(req, rpbSetBucketReq)
 	if err != nil {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1,10 +1,11 @@
 package riak
 
 import (
-	"github.com/bmizerany/assert"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
 
 func parseVersion(version string) (major, minor int) {
@@ -44,6 +45,9 @@ func TestBucket(t *testing.T) {
 	err = bucket.SetLastWriteWins(false)
 	assert.T(t, err == nil)
 
+	err = bucket.SetSearchIndex("search_test.go")
+	assert.T(t, (err == nil) || (err.Error()[0:42] == "Invalid bucket properties: [{search_index,"))
+
 	// Read and verify properties
 	bucket2, err := client.NewBucket("bucket_test.go")
 	assert.T(t, err == nil)
@@ -52,6 +56,7 @@ func TestBucket(t *testing.T) {
 
 	if (major > 1) || (major == 1 && minor >= 4) {
 		assert.T(t, bucket2.LastWriteWins() == false)
+		assert.T(t, bucket2.SearchIndex() == "")
 	}
 
 	// Set alternate properties


### PR DESCRIPTION
The code in this change-set adds `SearchIndex()` and `SetSearchIndex()` methods to buckets.

A search index equal to the empty string causes an error, and that's why the code checks for an empty index after the bucket prop struct is created.

As with previous search bits, testing is a major PITA because the index must be installed prior to testing.