### PR TITLE
Various fixs to Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ go:
 services:
   - riak
 install:
+  - riak-admin wait-for-service riak_kv riak@127.0.0.1
+  - riak-admin wait-for-service riak_search riak@127.0.0.1
   - cd $TRAVIS_BUILD_DIR
-  - go get -d -v
-  - go build -v
-  - go get -v github.com/bmizerany/assert
-  - go test -i
-script: go test
+  - go get -d -t -v
+  - go build -v ./...
+  - go test -i ./...
+script:
+  - go test ./...


### PR DESCRIPTION
 - Fix a random build failure where Riak would still be setting up
Riak Search when the search test is run, resulting in a failure.
Instead wait for Riak to have started the search service.  Also
wait for the kv service to start, in case that ever becomes a
problem in the future.
 - Instead of manually specifying the test dependencies, use the -t
option to go get.
 - Build/test all packages in the repository.  While they already
should have been, this ensures it in the future.