### PR TITLE
Calling close on the connection when receiving an EOF in Client.response...

### DIFF
--- a/client.go
+++ b/client.go
@@ -235,12 +235,12 @@ func (c *Client) response(conn *net.TCPConn, response proto.Message) (err error)
 	// Read the response from Riak
 	msgbuf, err := c.read(conn, 5)
 	if err != nil {
+		c.releaseConn(conn)
 		if err == io.EOF {
 			// Connection was closed, try to re-open the connection so subsequent
 			// i/o can succeed. Does report the error for this response.
-			conn, _ = net.DialTCP("tcp", nil, c.tcpaddr)
+			c.Close()
 		}
-		c.releaseConn(conn)
 		return err
 	}
 	defer c.releaseConn(conn)


### PR DESCRIPTION
... to reset the entire pool

Hello,

I ran into an issue while kill -9 testing a service we've built in go on top of Riak 2.0

It appears that once we get an EOF from riak going away, even if riak comes back, the pool is left in a state where the connections consistently return EOFs still. I took a look at the commit that added the original code into the repo, and it seemed like it was part of a larger refactor to consolidate how the pooled/non-pooled client behaved. It looked like the code was added new, and not ported, and I'm guessing may never have had the intended effect?

If this is not the right way to fix this issue, please let me know and I'll be happy to take a different approach.