### PR TITLE
Make the connection process race free

### DIFF
--- a/defaultclient.go
+++ b/defaultclient.go
@@ -16,7 +16,7 @@ func ConnectClient(addr string) (err error) {
 	if defaultClient != nil {
 		defaultClient.Close()
 	}
-	defaultClient = &Client{addr: addr, connected: false, readTimeout: 1e8, writeTimeout: 1e8, conn_count: 1}
+	defaultClient = NewClient(addr)
 	return defaultClient.Connect()
 }
 
@@ -30,7 +30,7 @@ func ConnectClientPool(addr string, count int) (err error) {
 	if defaultClient != nil {
 		defaultClient.Close()
 	}
-	defaultClient = &Client{addr: addr, connected: false, readTimeout: 1e8, writeTimeout: 1e8, conn_count: count}
+	defaultClient = NewClientPool(addr, count)
 	return defaultClient.Connect()
 }
 


### PR DESCRIPTION
When I closed PR #91, I realised the Connect/Close are inherently racy.  This PR makes use of the conns channel to avoid races.  Connect and close also gained a RWMutex to ensure they don't run at the same time, as they can race in their error paths.  Also only one Close is forced to run at a time, as otherwise it can deadlock.

Due to this work, I believe Connect can now be run in a separate goroutine when called in getConn, but we lose the ability for Connect to report errors.  Would this be worthwhile to try?  It would avoid blocking getConn when connections are now available.